### PR TITLE
fix getJSON

### DIFF
--- a/src/promise-xhr.js
+++ b/src/promise-xhr.js
@@ -49,10 +49,8 @@ xhr.get = function(url) {
  * @return {Promise}
  */
 xhr.getJSON = function(url) {
-    return new Promise((resolve, reject) => {
-        xhr.get(url).then((response) => {
-            resolve(JSON.parse(response))
-        })
+    return xhr.get(url).then((response) => {
+        return JSON.parse(response)
     })
 }
 


### PR DESCRIPTION
Previously, the case that xhr.get(url) failed was not handled so the promise was never settled.

I did not write any tests yet because I was not sure about how to set up the testing environment. Hope this is ok.